### PR TITLE
Redirect default Netlify subdomain to primary domain, add canonical links to head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Style focus state
 - Update docs link in Readme
 - Redirect default Netlify subdomain to primary domain
+- Update Eleventy
 
 ## 0.21.0 - 2019-03-26 - [CMS, Styles, Strict JS](https://github.com/paulshryock/New-Project-Starter-Kit/releases/tag/v0.21.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Readme description
 - Style focus state
 - Update docs link in Readme
+- Redirect default Netlify subdomain to primary domain
 
 ## 0.21.0 - 2019-03-26 - [CMS, Styles, Strict JS](https://github.com/paulshryock/New-Project-Starter-Kit/releases/tag/v0.21.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update docs link in Readme
 - Redirect default Netlify subdomain to primary domain
 - Update Eleventy
+- Put humans before robots
+- Add canonical links to head
 
 ## 0.21.0 - 2019-03-26 - [CMS, Styles, Strict JS](https://github.com/paulshryock/New-Project-Starter-Kit/releases/tag/v0.21.0)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # New Project Starter Kit
 
+[![Netlify Status](https://api.netlify.com/api/v1/badges/a1031bfd-6642-45fe-9547-2438c4bc0de4/deploy-status)](https://app.netlify.com/sites/npsk/deploys)
+
 Start new projects with webpack, Babel, Sass, PostCSS, Eleventy, PWA, service workers, JShint, and Netlify CMS installed and configured, with some common accessible HTML, CSS, and JS components and patterns. Includes deployment configuration for Netlify and Zeit Now.
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/a1031bfd-6642-45fe-9547-2438c4bc0de4/deploy-status)](https://app.netlify.com/sites/npsk/deploys)
+[NewProjectStarterKit.com](https://newprojectstarterkit.com/)
 
 ## Quick Start
 

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "title": "New Project Starter Kit",
   "version": "0.22.0",
   "description": "Start new projects with webpack, Babel, Sass, PostCSS, Eleventy, PWA, service workers, JShint, and Netlify CMS installed and configured, with some common accessible HTML, CSS, and JS components and patterns. Includes deployment configuration for Netlify and Zeit Now.",
-  "url": "https://example.com",
-  "company": "Example Corp",
+  "url": "https://newprojectstarterkit.com",
+  "company": "Paul Shryock",
   "private": true,
   "scripts": {
     "start": "npm run build",

--- a/src/_includes/_globals/head.liquid
+++ b/src/_includes/_globals/head.liquid
@@ -10,7 +10,7 @@
 		<meta name="description" content="{{ seo_description | default: excerpt | default: site.description }}">
 		<link rel="author" href="/humans.txt">
 		<meta name="robots" content="index,follow">
-		<link rel="canonical" href="{{ site.url }}{{ url }}">
+		<link rel="canonical" href="{{ site.url }}{{ page.url }}">
 
 		<!-- PWA -->
 		<link rel="manifest" href="/manifest.json">

--- a/src/_includes/_globals/head.liquid
+++ b/src/_includes/_globals/head.liquid
@@ -8,8 +8,9 @@
 		<!-- Page-specific information -->
 		<title>{{ seo_title | default: title | default: site.title }}</title>
 		<meta name="description" content="{{ seo_description | default: excerpt | default: site.description }}">
-		<meta name="robots" content="index,follow">
 		<link rel="author" href="/humans.txt">
+		<meta name="robots" content="index,follow">
+		<link rel="canonical" href="{{ site.url }}{{ url }}">
 
 		<!-- PWA -->
 		<link rel="manifest" href="/manifest.json">

--- a/src/_redirects
+++ b/src/_redirects
@@ -14,6 +14,9 @@
 # Redirect with a 301
 # /home         /              301
 
+# Redirect default Netlify subdomain to primary domain
+https://npsk.netlify.com/* https://newprojectstarterkit.com/:splat 301!
+
 # Redirect with a 302
 # /my-redirect  /              302
 

--- a/src/pages/form.md
+++ b/src/pages/form.md
@@ -38,7 +38,7 @@ nav_title: Form
 		</div>
 		<div>
 			<label for="a-datetime-local">Datetime-local</label>
-			<input type="datetime-local" value="1999-12-31 23:59" placeholder="enter a date and time in the YYYY-MM-DD HH:MM format" name="a-datetime-local" id="a-datetime-local" />
+			<input type="datetime-local" value="1999-12-31T23:59" placeholder="enter a date and time in the YYYY-MM-DD HH:MM format" name="a-datetime-local" id="a-datetime-local" />
 		</div>
 		<div>
 			<label for="an-email-address">Email</label>
@@ -54,7 +54,7 @@ nav_title: Form
 		</div>
 		<div>
 			<label for="an-image">Image</label>
-			<input type="image" src="http://clicknathan.com/wp-content/uploads/2014/05/red-button.png" width="50" height="50" name="an-image" id="an-image" />
+			<input type="image" src="https://clicknathan.com/wp-content/uploads/2014/05/red-button.png" width="50" height="50" name="an-image" id="an-image" />
 		</div>
 		<div>
 			<label for="a-month">Month</label>
@@ -62,7 +62,7 @@ nav_title: Form
 		</div>
 		<div>
 			<label for="a-week">Week</label>
-			<input type="week" value="2014-w52" placeholder="enter a year and week in the YYYY-wWW format where the 'w' is just a w, and the 'WW' represents the week number" name="a-week" id="a-week" />
+			<input type="week" value="2014-W52" placeholder="enter a year and week in the YYYY-wWW format where the 'w' is just a w, and the 'WW' represents the week number" name="a-week" id="a-week" />
 		</div>
 		<div>
 			<label for="a-number">Number</label>
@@ -70,7 +70,7 @@ nav_title: Form
 		</div>
 		<div>
 			<label for="a-password">Password</label>
-			<input type="password" value="" placeholder="enter a password" name="a-password" id="a-password" />
+			<input type="password" value="" placeholder="enter a password" name="a-password" id="a-password" autocomplete="current-password" />
 		</div>
 		<div>
 			<label for="a-range">Range</label>

--- a/src/pages/form.md
+++ b/src/pages/form.md
@@ -7,10 +7,6 @@ navigation: 4
 nav_title: Form
 ---
 
-<header>
-	<h1 class="post-title">Form</h1>
-</header>
-
 <div>
 	<ul class="list_bulleted">
 		<li><a href="#inputs">Inputs</a></li>


### PR DESCRIPTION
### Changed
- Redirect default Netlify subdomain to primary domain
- Add canonical links to head

### Additional Changes
- Put humans before robots in the head file -- seems like a nice self-reminder to put people first

# Checklist
- [x] I have tested this code
- [x] I have updated the Changelog
- [ ] I have updated the Docs
- [x] I have updated the Readme
- [ ] I have updated the package.json version