### PR TITLE
Fix image and font directory locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Put humans before robots
 - Add canonical links to head
 
+### Fixed
+- Fix favicon directory locations
+
 ## 0.21.0 - 2019-03-26 - [CMS, Styles, Strict JS](https://github.com/paulshryock/New-Project-Starter-Kit/releases/tag/v0.21.0)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add canonical links to head
 
 ### Fixed
-- Fix favicon directory locations
+- Fix image and font directory locations
 
 ## 0.21.0 - 2019-03-26 - [CMS, Styles, Strict JS](https://github.com/paulshryock/New-Project-Starter-Kit/releases/tag/v0.21.0)
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,6 +60,22 @@ module.exports = {
             loader: 'image-webpack-loader'
           }
         ]
+      },
+      {
+        test: /\.(woff|woff2|eot|ttf|svg)$/,
+        include: path.resolve(__dirname, 'src/_assets/fonts'),
+        use: {
+          loader: "file-loader",
+            options: {
+              name: '[name].[ext]',
+              outputPath: (url, resourcePath, context) => {
+                const urlParts = url.split( '-' ),
+                      fontFamily = urlParts[0],
+                      fontWeight = urlParts[1];
+                return `/fonts/${fontFamily}/${fontWeight}/${url}`;
+              },
+            }
+        }
       }
     ]
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,11 +47,12 @@ module.exports = {
       },
       {
         test: /\.(gif|png|jpe?g|svg)$/i,
+        include: path.resolve(__dirname, 'src/_assets/img'),
         use: [
           {
             loader: 'file-loader',
             options: {
-              name: '[name].[ext]',
+              name: '[folder]/[name].[ext]',
               outputPath: 'img'
             }
           },


### PR DESCRIPTION
# Description

When webpack process images and fonts, they aren't all saved in the correct subdirectories. This causes 404 errors when those resources are called on the front end. Update the webpack configuration.

Closes #64

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [x] I have updated the Changelog
- [ ] I have updated the Docs
- [ ] I have updated the Readme
- [ ] I have updated the package.json version