### PR TITLE
Add logout and protect against CSRF attack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,24 @@ and this project adheres to [Semantic Versioning](semver).
 - [ ] Archive paulshryock/Express-Starter repo
 - [ ] Rename database(s)
 
+## 0.29.0 - 2020-04-19 - Improve authorization
+
+### Added
+- Add token refresh
+- Add logout
+- During authorization, if `origin` or `referrer` header doesn't match current domain, deny access
+- During authorization, if token is expired, deny access
+- Add token creation time and expiration
+
+### Changed
+- Only send HSTS header in production
+- Update token cookie `maxAge` to 1 week
+- When creating user, only set secure cookie in production
+- Update token body properties
+
+### Removed
+- Remove logout middleware
+
 ## 0.28.0 - 2020-04-17 - Add Express server
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npsk",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "private": false,
   "license": "Hippocratic License v1.0",
   "author": {

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -76,9 +76,9 @@ const helmetHeaders = {
     action: 'deny'
   },
   hsts: {
-    maxAge: 31536000, // 1 year
-    includeSubDomains: true,
-    preload: true
+    maxAge: isProduction ? 31536000 : 0, // 1 year
+    includeSubDomains: isProduction ? true : null,
+    preload: isProduction ? true : null
   },
   referrerPolicy: {
     policy: 'strict-origin-when-cross-origin'

--- a/src/server/handlers/auth.js
+++ b/src/server/handlers/auth.js
@@ -1,7 +1,7 @@
 const { log } = require('../modules/logger')
 const { User, validate } = require('../models/user')
-const bcrypt = require('bcrypt')
 const _ = require('lodash')
+const bcrypt = require('bcrypt')
 const app = require('express')()
 const isProduction = app.get('env') === 'production'
 
@@ -55,5 +55,18 @@ module.exports = {
       })
       // Send the response
       .send('Login successful.')
+  },
+
+  /**
+   * Log out a user
+   */
+  logoutUser: async (req, res) => {
+    log.info('User logged out.')
+
+    res
+      // Remove a cookie
+      .clearCookie('x-auth-token')
+      // Send the response
+      .send('Logout successful.')
   }
 }

--- a/src/server/handlers/auth.js
+++ b/src/server/handlers/auth.js
@@ -36,25 +36,64 @@ module.exports = {
       return res.status(400).send('Invalid email or password')
     }
 
-    log.info('User logged in.', { user: _.pick(user, ['_id', 'email', 'role']) })
-
     // Generate auth token
     const token = user.generateAuthToken()
+
+    log.info('User logged in.', { user: _.pick(user, ['_id', 'email', 'role']) })
 
     // Return auth token to the client
     res
       // Set a cookie
       .cookie('x-auth-token', token, {
         httpOnly: isProduction,
-        maxAge: 60 * 60 * 1000, // 1 hour
-        // maxAge: 24 * 60 * 60 * 1000, // 1 day
-        // maxAge: 7 * 24 * 60 * 60 * 1000, // 1 week
+        maxAge: 7 * 24 * 60 * 60 * 1000, // 1 week
         // path: '/',
         sameSite: isProduction,
         secure: isProduction,
       })
       // Send the response
       .send('Login successful.')
+  },
+
+  /**
+   * Refresh a user token
+   */
+  refreshUserToken: async (req, res) => {
+    // Verify user exists
+    let user = await User.findOne({ email: req.body.email })
+    if (!user) {
+      log.info('Failed token refresh attempt: User does not exist.', { user: req.body.email })
+      return res.status(400).send('User does not exist.')
+    }
+
+    // Get current token
+    const token = req.cookies['x-auth-token']
+
+    // If no token, deny access
+    if (!token) {
+      log.error('Access denied. No token provided.', { status: 401 })
+      return res
+        .status(401)
+        .send('Access denied. No token provided.')
+    }
+
+    // Refresh the token
+    const refreshed = user.refreshAuthToken(token)
+
+    log.info('User token refreshed.', { user: _.pick(user, ['_id', 'email', 'role']) })
+
+    // Return refreshed auth token to the client
+    res
+      // Set a cookie
+      .cookie('x-auth-token', refreshed, {
+        httpOnly: isProduction,
+        maxAge: 7 * 24 * 60 * 60 * 1000, // 1 week
+        // path: '/',
+        sameSite: isProduction,
+        secure: isProduction,
+      })
+      // Send the response
+      .send('Token refresh successful.')
   },
 
   /**

--- a/src/server/handlers/users.js
+++ b/src/server/handlers/users.js
@@ -2,6 +2,8 @@ const { log } = require('../modules/logger')
 const { User, validate } = require('../models/user')
 const _ = require('lodash')
 const bcrypt = require('bcrypt')
+const app = require('express')()
+const isProduction = app.get('env') === 'production'
 
 module.exports = {
   /**
@@ -63,13 +65,13 @@ module.exports = {
     res
       // Set a cookie
       .cookie('x-auth-token', token, {
-        httpOnly: true,
+        httpOnly: isProduction,
         maxAge: 60 * 60 * 1000, // 1 hour
         // maxAge: 24 * 60 * 60 * 1000, // 1 day
         // maxAge: 7 * 24 * 60 * 60 * 1000, // 1 week
         // path: '/',
-        sameSite: true,
-        secure: true
+        sameSite: isProduction,
+        secure: isProduction
       })
       // Set a header
       // .header('x-auth-token', token)

--- a/src/server/handlers/users.js
+++ b/src/server/handlers/users.js
@@ -84,7 +84,7 @@ module.exports = {
    */
   getCurrentUser: async (req, res) => {
     // Get current user
-    const user = await User.findById(req.user._id).select('-password')
+    const user = await User.findById(req.user.sub).select('-password')
     
     // Return user to the client
     res.send(user)
@@ -117,7 +117,7 @@ module.exports = {
     }
     if (req.body.role) requestBody.role = req.body.role
 
-    const user = await User.findByIdAndUpdate(req.user._id, requestBody, { new: true })
+    const user = await User.findByIdAndUpdate(req.user.sub, requestBody, { new: true })
 
     // If user does not exist, return 404 error to the client
     if (!user) return res.status(404).send('"id" was not found')
@@ -133,7 +133,7 @@ module.exports = {
    */
   deleteCurrentUser: async (req, res) => {
     // Remove user from database, if it exists
-    const user = await User.findByIdAndRemove(req.user._id)
+    const user = await User.findByIdAndRemove(req.user.sub)
 
     // If user does not exist, return 404 error to the client
     if (!user) return res.status(404).send('"id" was not found')

--- a/src/server/middleware/auth.js
+++ b/src/server/middleware/auth.js
@@ -9,6 +9,7 @@ module.exports = function (req, res, next) {
   const referrer = req.header('referrer')
   const url = config.get('app.url')
 
+  // If origin or referrer doesn't match, deny access
   if (
     (origin && origin !== url) ||
     (referrer && referrer !== url)
@@ -22,6 +23,7 @@ module.exports = function (req, res, next) {
   // Check cookie
   const token = req.cookies['x-auth-token']
 
+  // If no token, deny access
   if (!token) {
     log.error('Access denied. No token provided.', { status: 401 })
     return res
@@ -30,7 +32,19 @@ module.exports = function (req, res, next) {
   }
 
   try {
+    // Decode and verify the token signature
     const decoded = jwt.verify(token, config.get('jwtPrivateKey'))
+    const isExpired = Date.now() > decoded.exp
+
+    // If token is expired, deny access
+    if (isExpired) {
+      log.error('Access denied. Token is expired.', { status: 401 })
+      return res
+        .status(401)
+        .send('Access denied. Token is expired.')
+    }
+
+    // Set user to decoded token and continue
     req.user = decoded
     next()
   }

--- a/src/server/middleware/logout.js
+++ b/src/server/middleware/logout.js
@@ -1,2 +1,0 @@
-// Clear a cookie
-// response.clearCookie('nameOfCookie')

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -19,9 +19,33 @@ const userSchema = new mongoose.Schema({
 userSchema.plugin(uniqueValidator)
 
 userSchema.methods.generateAuthToken = function() {
-  const token = jwt.sign({ _id: this._id, role: this.role }, config.get('jwtPrivateKey'))
+  const token = jwt.sign({
+    sub: this._id, // subject
+    role: this.role,
+    exp: Date.now() + 7 * 24 * 60 * 60 * 1000, // expires in 1 week
+    iat: Date.now() // Creation time
+  }, config.get('jwtPrivateKey'))
 
   return token
+}
+
+userSchema.methods.refreshAuthToken = function(token) {
+  // Set the token expiration to one week
+  // and refresh the token every time the user
+  // opens the **web application** and every one hour.
+
+  // If a user doesn't open the **application** for more than a week,
+  // they will have to login again
+  // and this is acceptable **web application** UX.
+
+  const refreshed = jwt.sign({
+    sub: token.sub, // subject
+    role: token.role,
+    exp: Date.now() + 7 * 24 * 60 * 60 * 1000, // expires in 1 week
+    iat: token.iat // Creation time
+  }, config.get('jwtPrivateKey'))
+
+  return refreshed
 }
 
 /**

--- a/src/server/routes/auth.js
+++ b/src/server/routes/auth.js
@@ -1,6 +1,7 @@
 const router = require('express').Router()
 const handlers = require('../handlers/auth')
 const rateLimit = require('express-rate-limit')
+const auth = require('../middleware/auth')
 
 const limiter = rateLimit({
   windowMs: 1 * 60 * 1000, // 1 minute
@@ -8,5 +9,6 @@ const limiter = rateLimit({
 })
 
 router.post('/', limiter, handlers.authenticateUser)
+router.post('/logout', [auth, limiter], handlers.logoutUser)
 
 module.exports = router

--- a/src/server/routes/auth.js
+++ b/src/server/routes/auth.js
@@ -9,6 +9,7 @@ const limiter = rateLimit({
 })
 
 router.post('/', limiter, handlers.authenticateUser)
+router.post('/refresh', [auth, limiter], handlers.refreshUserToken)
 router.post('/logout', [auth, limiter], handlers.logoutUser)
 
 module.exports = router


### PR DESCRIPTION
### Added
- Add token refresh
- Add logout
- During authorization, if `origin` or `referrer` header doesn't match current domain, deny access
- During authorization, if token is expired, deny access
- Add token creation time and expiration

### Changed
- Only send HSTS header in production
- Update token cookie `maxAge` to 1 week
- When creating user, only set secure cookie in production
- Update token body properties

### Removed
- Remove logout middleware

## Checklist
- [x] I have tested this code
- [x] I have updated the Changelog
- [ ] I have updated the Docs
- [ ] I have updated the Readme
- [x] I have updated the package.json version